### PR TITLE
feat: timer negative variable

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,3 +27,4 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           path: './pkg'
+          name: 'getontime-ontime'

--- a/companion/manifest.json
+++ b/companion/manifest.json
@@ -3,7 +3,7 @@
 	"name": "getontime-ontime",
 	"shortname": "ontime",
 	"description": "Companion module for ontime",
-	"version": "4.0.1",
+	"version": "4.0.2",
 	"license": "MIT",
 	"repository": "git+https://github.com/bitfocus/companion-module-getontime-ontime.git",
 	"bugs": "https://github.com/bitfocus/companion-module-getontime-ontime/issues",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "getontime-ontime",
-	"version": "4.0.1",
+	"version": "4.0.2",
 	"main": "/dist/index.js",
 	"license": "MIT",
 	"prettier": "@companion-module/tools/.prettierrc.json",

--- a/src/enums.ts
+++ b/src/enums.ts
@@ -84,6 +84,7 @@ export enum variableId {
 	TimeH = 'time_h',
 	TimeM = 'time_m',
 	TimeS = 'time_s',
+	TimeN = 'time_n',
 
 	IdNow = 'idNow',
 	TitleNow = 'titleNow',

--- a/src/enums.ts
+++ b/src/enums.ts
@@ -84,7 +84,7 @@ export enum variableId {
 	TimeH = 'time_h',
 	TimeM = 'time_m',
 	TimeS = 'time_s',
-	TimeN = 'time_n',
+	TimeN = 'time_sign',
 
 	IdNow = 'idNow',
 	TitleNow = 'titleNow',

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -14,6 +14,7 @@ const defaultTimerObject = {
 	hoursMinutes: '--:--',
 	hoursMinutesSeconds: '--:--:--',
 	delayString: '0',
+	negative: '',
 }
 
 type SplitTime = typeof defaultTimerObject
@@ -35,19 +36,20 @@ export function msToSplitTime(time: number | null): SplitTime {
 
 	const seconds = padTo2Digits(s)
 	const minutes = padTo2Digits(m)
-	const hours = (negative ? '-' : '') + padTo2Digits(h)
+	const hours = padTo2Digits(h)
+	const negativeSign = negative ? '-' : ''
 
 	const hoursMinutes = `${hours}:${minutes}`
-	const hoursMinutesSeconds = `${hoursMinutes}:${seconds}`
+	const hoursMinutesSeconds = `${negativeSign}${hoursMinutes}:${seconds}`
 
 	let delayString = '00'
 
 	if (h && !m && !s) {
-		delayString = `${negative ? '-' : '+'}${h}h`
+		delayString = `${negativeSign}${h}h`
 	} else if (!h && m && !s) {
-		delayString = `${negative ? '-' : '+'}${m}m`
+		delayString = `${negativeSign}${m}m`
 	} else if (!h && !m && s) {
-		delayString = `${negative ? '-' : '+'}${s}s`
+		delayString = `${negativeSign}${s}s`
 	}
 
 	return {
@@ -57,6 +59,7 @@ export function msToSplitTime(time: number | null): SplitTime {
 		hoursMinutes,
 		hoursMinutesSeconds,
 		delayString,
+		negative: negativeSign,
 	}
 }
 

--- a/src/v3/connection.ts
+++ b/src/v3/connection.ts
@@ -92,6 +92,7 @@ export function connect(self: OnTimeInstance, ontime: OntimeV3): void {
 		ontime.state.companionSpecific.timerZone = timerZone
 		self.setVariableValues({
 			[variableId.TimerTotalMs]: val.current ?? 0,
+			[variableId.TimeN]: timer.negative,
 			[variableId.Time]: timer.hoursMinutesSeconds,
 			[variableId.TimeHM]: timer.hoursMinutes,
 			[variableId.TimeH]: timer.hours,

--- a/src/v3/variables.ts
+++ b/src/v3/variables.ts
@@ -47,7 +47,7 @@ export function variables(): CompanionVariableDefinition[] {
 			variableId: variableId.TimeS,
 		},
 		{
-			name: 'Current event state Negative',
+			name: 'Current event timer Sign',
 			variableId: variableId.TimeN,
 		},
 		//timer.duration

--- a/src/v3/variables.ts
+++ b/src/v3/variables.ts
@@ -46,6 +46,10 @@ export function variables(): CompanionVariableDefinition[] {
 			name: 'Current event state Seconds',
 			variableId: variableId.TimeS,
 		},
+		{
+			name: 'Current event state Negative',
+			variableId: variableId.TimeN,
+		},
 		//timer.duration
 		//timer.elapsed
 		//timer.expectedFinish


### PR DESCRIPTION
fixes #56


variable: `$(ontime:time_h)` no longer includes a `-` if the timer is negative
new variable `$(ontime:time_sign)` is `-` or empty depending on if the timer is negative
