### PR TITLE
fix Aux timer action and add aux timer feedback and preset

### DIFF
--- a/companion/manifest.json
+++ b/companion/manifest.json
@@ -3,7 +3,7 @@
 	"name": "getontime-ontime",
 	"shortname": "ontime",
 	"description": "Companion module for ontime",
-	"version": "4.0.2",
+	"version": "4.1.0",
 	"license": "MIT",
 	"repository": "git+https://github.com/bitfocus/companion-module-getontime-ontime.git",
 	"bugs": "https://github.com/bitfocus/companion-module-getontime-ontime/issues",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "getontime-ontime",
-	"version": "4.0.2",
+	"version": "4.1.0",
 	"main": "/dist/index.js",
 	"license": "MIT",
 	"prettier": "@companion-module/tools/.prettierrc.json",

--- a/src/enums.ts
+++ b/src/enums.ts
@@ -53,6 +53,9 @@ export enum feedbackId {
 	TimerZone = 'timerZone',
 
 	RundownOffset = 'rundownOffset',
+
+	AuxTimerPlayback = 'auxTimerPlayback',
+	AuxTimerNegative = 'auxTimerNegativePlayback',
 }
 
 export enum deprecatedFeedbackId {

--- a/src/enums.ts
+++ b/src/enums.ts
@@ -45,7 +45,6 @@ export enum deprecatedActionId {
 
 export enum feedbackId {
 	ColorPlayback = 'colorPlayback',
-	ColorNegative = 'timer_negative',
 	ColorAddRemove = 'state_color_add_remove',
 	OnAir = 'onAir',
 	MessageVisible = 'messageVisible',
@@ -66,6 +65,7 @@ export enum deprecatedFeedbackId {
 	ColorPaused = 'state_color_paused',
 	ColorStopped = 'state_color_stopped',
 	ColorRoll = 'state_color_roll',
+	ColorNegative = 'timer_negative',
 }
 
 export enum variableId {

--- a/src/upgrades.ts
+++ b/src/upgrades.ts
@@ -10,6 +10,7 @@ import {
 } from '@companion-module/base'
 import type { OntimeConfig } from './config'
 import { feedbackId, ActionId, deprecatedActionId, deprecatedFeedbackId } from './enums'
+import { TimerZone } from './v3/ontime-types'
 
 function update2x4x0(
 	_context: CompanionUpgradeContext<OntimeConfig>,
@@ -235,6 +236,10 @@ function update3x4x0(
 				feedback.feedbackId = feedbackId.MessageVisible
 				feedback.options.source = 'timer'
 				feedback.options.reqText = false
+				result.updatedFeedbacks.push(feedback)
+			} else if (feedback.feedbackId === deprecatedFeedbackId.ColorNegative) {
+				feedback.feedbackId = feedbackId.TimerZone
+				feedback.options.state = TimerZone.Overtime
 				result.updatedFeedbacks.push(feedback)
 			}
 		}

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -1,5 +1,6 @@
 import { DropdownChoice } from '@companion-module/base'
-import { OntimeEvent, TimerZone } from './v3/ontime-types.js'
+import { OntimeEvent, RuntimeStore, SimpleTimerState, TimerZone } from './v3/ontime-types.js'
+import { OntimeV3 } from './v3/ontimev3.js'
 
 export const joinTime = (...args: string[]) => args.join(':')
 
@@ -86,4 +87,8 @@ export function extractTimerZone(
 		return TimerZone.Danger
 	}
 	return TimerZone.Overtime
+}
+
+export function getAuxTimerState(ontime: OntimeV3, index = 'auxtimer1') {
+	return ontime.state[index as keyof RuntimeStore] as unknown as SimpleTimerState
 }

--- a/src/v3/actions/auxTimer.ts
+++ b/src/v3/actions/auxTimer.ts
@@ -3,13 +3,13 @@ import { socketSendJson } from '../connection'
 import { ActionId } from '../../enums'
 import { OntimeV3 } from '../ontimev3'
 import { ActionCommand } from './commands'
-import { RuntimeStore, SimpleDirection, SimplePlayback, SimpleTimerState } from '../ontime-types'
+import { SimpleDirection, SimplePlayback } from '../ontime-types'
+import { getAuxTimerState } from '../../utilities'
 
 export function createAuxTimerActions(ontime: OntimeV3): { [id: string]: CompanionActionDefinition } {
 	function togglePlayState(action: CompanionActionEvent): void {
-		const id = action.options.destination as string
-		const timer = ontime.state[('timer' + id) as keyof RuntimeStore] as SimpleTimerState
-
+		const id = (action.options.destination ?? '1') as string
+		const timer = getAuxTimerState(ontime)
 		if (action.options.value === 'toggleSS') {
 			socketSendJson(ActionCommand.AuxTimer, {
 				[id]: timer.playback === SimplePlayback.Start ? SimplePlayback.Stop : SimplePlayback.Start,
@@ -111,10 +111,10 @@ export function createAuxTimerActions(ontime: OntimeV3): { [id: string]: Compani
 			options: [
 				{
 					type: 'dropdown',
-					choices: [{ id: '1', label: 'Extra Timer 1' }],
+					choices: [{ id: '1', label: 'Aux Timer 1' }],
 					default: '1',
 					id: 'destination',
-					label: 'Select Extra Timer',
+					label: 'Select Aux Timer',
 					isVisible: () => false, //This Stays hidden for now
 				},
 				{

--- a/src/v3/actions/commands.ts
+++ b/src/v3/actions/commands.ts
@@ -8,5 +8,5 @@ export enum ActionCommand {
 	Add = 'addtime',
 	Message = 'message',
 	Change = 'change',
-	AuxTimer = 'extraTimer',
+	AuxTimer = 'auxtimer',
 }

--- a/src/v3/connection.ts
+++ b/src/v3/connection.ts
@@ -108,7 +108,6 @@ export function connect(self: OnTimeInstance, ontime: OntimeV3): void {
 
 		self.checkFeedbacks(
 			feedbackId.ColorPlayback,
-			feedbackId.ColorNegative,
 			feedbackId.ColorAddRemove,
 			feedbackId.TimerZone
 		)

--- a/src/v3/connection.ts
+++ b/src/v3/connection.ts
@@ -106,11 +106,7 @@ export function connect(self: OnTimeInstance, ontime: OntimeV3): void {
 			[variableId.PlayState]: val.playback,
 		})
 
-		self.checkFeedbacks(
-			feedbackId.ColorPlayback,
-			feedbackId.ColorAddRemove,
-			feedbackId.TimerZone
-		)
+		self.checkFeedbacks(feedbackId.ColorPlayback, feedbackId.ColorAddRemove, feedbackId.TimerZone)
 	}
 
 	const updateMessage = (val: MessageState) => {
@@ -166,7 +162,7 @@ export function connect(self: OnTimeInstance, ontime: OntimeV3): void {
 	}
 
 	const updateAuxTimer1 = (val: SimpleTimerState) => {
-		ontime.state.timer1 = val
+		ontime.state.auxtimer1 = val
 		const duration = msToSplitTime(val.duration)
 		const current = msToSplitTime(val.current)
 
@@ -178,6 +174,7 @@ export function connect(self: OnTimeInstance, ontime: OntimeV3): void {
 			[variableId.AuxTimerPalyback + '-1']: val.playback,
 			[variableId.AuxTimerDirection + '-1']: val.direction,
 		})
+		self.checkFeedbacks(feedbackId.AuxTimerNegative, feedbackId.AuxTimerPlayback)
 	}
 
 	ws.onmessage = (event: any) => {

--- a/src/v3/feedbacks/auxTimer.ts
+++ b/src/v3/feedbacks/auxTimer.ts
@@ -1,0 +1,62 @@
+import { CompanionFeedbackDefinition, combineRgb } from '@companion-module/base'
+import { OntimeV3 } from '../ontimev3'
+import { feedbackId } from '../../enums'
+import { SimplePlayback } from '../ontime-types'
+import { getAuxTimerState } from '../../utilities'
+
+export function createAuxTimerFeedbacks(ontime: OntimeV3): { [id: string]: CompanionFeedbackDefinition } {
+	return {
+		[feedbackId.AuxTimerPlayback]: {
+			type: 'boolean',
+			name: 'Aux Timer Playback state',
+			description: 'Indicator colour for playback state',
+			defaultStyle: {
+				color: combineRgb(255, 255, 255),
+				bgcolor: combineRgb(0, 204, 0),
+			},
+			options: [
+				{
+					type: 'dropdown',
+					choices: [{ id: 'auxtimer1', label: 'Aux Timer 1' }],
+					default: 'auxtimer1',
+					id: 'destination',
+					label: 'Select Aux Timer',
+					isVisible: () => false, //This Stays hidden for now
+				},
+				{
+					type: 'dropdown',
+					label: 'State',
+					id: 'state',
+					choices: [
+						{ id: SimplePlayback.Start, label: 'Play' },
+						{ id: SimplePlayback.Pause, label: 'Pause' },
+						{ id: SimplePlayback.Stop, label: 'Stop' },
+					],
+					default: SimplePlayback.Start,
+				},
+			],
+			callback: (feedback) =>
+				getAuxTimerState(ontime, feedback.options.id as string).playback === feedback.options.state,
+		},
+		[feedbackId.AuxTimerNegative]: {
+			type: 'boolean',
+			name: 'Aux Timer negative',
+			description: 'Indicator colour for Aux Timer negative',
+			defaultStyle: {
+				color: combineRgb(255, 255, 255),
+				bgcolor: combineRgb(0, 204, 0),
+			},
+			options: [
+				{
+					type: 'dropdown',
+					choices: [{ id: 'auxtimer1', label: 'Aux Timer 1' }],
+					default: 'auxtimer1',
+					id: 'destination',
+					label: 'Select Aux Timer',
+					isVisible: () => false, //This Stays hidden for now
+				},
+			],
+			callback: (feedback) => getAuxTimerState(ontime, feedback.options.id as string).current < 0,
+		},
+	}
+}

--- a/src/v3/feedbacks/index.ts
+++ b/src/v3/feedbacks/index.ts
@@ -4,6 +4,7 @@ import { createPlaybackFeedbacks } from './playback'
 import { createMessageFeedbacks } from './message'
 import { createTimerZoneFeedback } from './timerZone'
 import { createOffsetFeedbacks } from './offset'
+import { createAuxTimerFeedbacks } from './auxTimer'
 
 export function feedbacks(ontime: OntimeV3): CompanionFeedbackDefinitions {
 	const feedbacks: { [id: string]: CompanionFeedbackDefinition | undefined } = {
@@ -11,6 +12,7 @@ export function feedbacks(ontime: OntimeV3): CompanionFeedbackDefinitions {
 		...createMessageFeedbacks(ontime),
 		...createTimerZoneFeedback(ontime),
 		...createOffsetFeedbacks(ontime),
+		...createAuxTimerFeedbacks(ontime),
 	}
 
 	return feedbacks

--- a/src/v3/ontime-types.ts
+++ b/src/v3/ontime-types.ts
@@ -73,7 +73,7 @@ export type RuntimeStore = {
 	// publicEventNext: OntimeEvent | null
 
 	// extra timers
-	timer1: SimpleTimerState
+	auxtimer1: SimpleTimerState
 }
 
 export type TimerState = {

--- a/src/v3/presets.ts
+++ b/src/v3/presets.ts
@@ -644,14 +644,17 @@ const auxTimerPresets: { [id: string]: CompanionButtonPresetDefinition } = {
 	start_stop_auxtimer: {
 		type: 'button',
 		category: 'Aux Timer',
-		name: 'Start/Stops Aux Timer',
+		name: 'Start/Stop Aux Timer',
 		style: {
 			...defaultWithIconStyle,
+			png64: icons.PlaybackStart,
+			text: 'START',
+			color: PlaybackGreen,
 		},
 		previewStyle: {
 			...defaultWithIconStyle,
 			png64: icons.PlaybackStart,
-			text: 'START',
+			text: 'START/STOP',
 			bgcolor: PlaybackGreen,
 		},
 		steps: [
@@ -669,25 +672,52 @@ const auxTimerPresets: { [id: string]: CompanionButtonPresetDefinition } = {
 			{
 				feedbackId: feedbackId.AuxTimerPlayback,
 				options: {
-					state: 'stop',
-				},
-				style: {
-					bgcolor: PlaybackGreen,
-					color: White,
-					png64: icons.PlaybackStart,
-					text: 'START',
-				},
-			},
-			{
-				feedbackId: feedbackId.AuxTimerPlayback,
-				options: {
 					state: 'start',
 				},
 				style: {
-					bgcolor: PlaybackRed,
-					color: White,
+					color: PlaybackRed,
 					png64: icons.PlaybackStop,
 					text: 'STOP',
+				},
+			},
+		],
+	},
+	pause_auxtimer: {
+		type: 'button',
+		category: 'Aux Timer',
+		name: 'Pause Aux Timer',
+		style: {
+			...defaultWithIconStyle,
+			png64: icons.PlaybackPause,
+			text: 'PAUSE',
+			color: PauseOrange,
+		},
+		previewStyle: {
+			...defaultWithIconStyle,
+			png64: icons.PlaybackPause,
+			text: 'PAUSE',
+			bgcolor: PauseOrange,
+		},
+		steps: [
+			{
+				down: [
+					{
+						actionId: ActionId.AuxTimerPlayState,
+						options: { value: 'pause' },
+					},
+				],
+				up: [],
+			},
+		],
+		feedbacks: [
+			{
+				feedbackId: feedbackId.AuxTimerPlayback,
+				options: {
+					state: 'pause',
+				},
+				style: {
+					bgcolor: PauseOrange,
+					color: White,
 				},
 			},
 		],

--- a/src/v3/presets.ts
+++ b/src/v3/presets.ts
@@ -9,7 +9,7 @@ import { ActionId, feedbackId } from '../enums'
 import { TimerZone } from './ontime-types'
 
 export function presets(): CompanionPresetDefinitions {
-	return { ...playbackPresets, ...timerPresets }
+	return { ...playbackPresets, ...timerPresets, ...auxTimerPresets }
 }
 
 const White = combineRgb(255, 255, 255)
@@ -533,13 +533,13 @@ const timerPresets: { [id: string]: CompanionButtonPresetDefinition } = {
 		style: {
 			...defaultStyle,
 			size: 44,
-			text: `$(ontime:time_h)`,
+			text: `$(ontime:time_sign)$(ontime:time_h)`,
 			alignment: 'center:center',
 		},
 		previewStyle: {
 			...defaultStyle,
-			size: 44,
-			text: 'HH',
+			size: 'auto',
+			text: '+/-HH',
 			alignment: 'center:center',
 			bgcolor: NormalGray,
 			color: Black,
@@ -603,5 +603,93 @@ const timerPresets: { [id: string]: CompanionButtonPresetDefinition } = {
 			},
 		],
 		feedbacks: timerZoneAndPauseFeedback,
+	},
+}
+
+const auxTimerNegative = [
+	{
+		feedbackId: feedbackId.AuxTimerNegative,
+		options: {},
+		style: {
+			color: DangerRed,
+		},
+	},
+]
+
+const auxTimerPresets: { [id: string]: CompanionButtonPresetDefinition } = {
+	current_time_hms: {
+		type: 'button',
+		category: 'Aux Timer',
+		name: 'Current timer ',
+		style: {
+			...defaultStyle,
+			text: `$(ontime:auxTimer_current_hms-1)`,
+			size: '14',
+			alignment: 'center:center',
+		},
+		previewStyle: {
+			...defaultStyle,
+			text: 'HH:MM:SS',
+			size: '14',
+			alignment: 'center:center',
+		},
+		steps: [
+			{
+				down: [],
+				up: [],
+			},
+		],
+		feedbacks: auxTimerNegative,
+	},
+	start_stop_auxtimer: {
+		type: 'button',
+		category: 'Aux Timer',
+		name: 'Start/Stops Aux Timer',
+		style: {
+			...defaultWithIconStyle,
+		},
+		previewStyle: {
+			...defaultWithIconStyle,
+			png64: icons.PlaybackStart,
+			text: 'START',
+			bgcolor: PlaybackGreen,
+		},
+		steps: [
+			{
+				down: [
+					{
+						actionId: ActionId.AuxTimerPlayState,
+						options: { value: 'toggleSS' },
+					},
+				],
+				up: [],
+			},
+		],
+		feedbacks: [
+			{
+				feedbackId: feedbackId.AuxTimerPlayback,
+				options: {
+					state: 'stop',
+				},
+				style: {
+					bgcolor: PlaybackGreen,
+					color: White,
+					png64: icons.PlaybackStart,
+					text: 'START',
+				},
+			},
+			{
+				feedbackId: feedbackId.AuxTimerPlayback,
+				options: {
+					state: 'start',
+				},
+				style: {
+					bgcolor: PlaybackRed,
+					color: White,
+					png64: icons.PlaybackStop,
+					text: 'STOP',
+				},
+			},
+		],
 	},
 }

--- a/src/v3/presets.ts
+++ b/src/v3/presets.ts
@@ -620,7 +620,7 @@ const auxTimerPresets: { [id: string]: CompanionButtonPresetDefinition } = {
 	current_time_hms: {
 		type: 'button',
 		category: 'Aux Timer',
-		name: 'Current timer ',
+		name: 'Current aux time',
 		style: {
 			...defaultStyle,
 			text: `$(ontime:auxTimer_current_hms-1)`,

--- a/src/v3/state.ts
+++ b/src/v3/state.ts
@@ -30,7 +30,7 @@ const stateobj: RuntimeStore & { companionSpecific: { timerZone: TimerZone } } =
 	},
 	eventNow: null,
 	eventNext: null,
-	timer1: {
+	auxtimer1: {
 		duration: 0,
 		current: 0,
 		playback: SimplePlayback.Stop,


### PR DESCRIPTION
- remove feedback ColorNegative as it is replaced by TimerZone (upgrade script exists)
- fix aux timer actions was using the old `extratimer` naming
- add aux timer feedback
   - Aux Timer Playback state
   - Aux Timer negative
- add aux timer presets
   - Current aux time
   - Start/Stop Aux Timer
   - Pause Aux Timer