### PR TITLE
Prev event

### DIFF
--- a/companion/manifest.json
+++ b/companion/manifest.json
@@ -3,7 +3,7 @@
 	"name": "getontime-ontime",
 	"shortname": "ontime",
 	"description": "Companion module for ontime",
-	"version": "4.2.0",
+	"version": "4.3.0",
 	"license": "MIT",
 	"repository": "git+https://github.com/bitfocus/companion-module-getontime-ontime.git",
 	"bugs": "https://github.com/bitfocus/companion-module-getontime-ontime/issues",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "getontime-ontime",
-	"version": "4.2.0",
+	"version": "4.3.0",
 	"main": "/dist/index.js",
 	"license": "MIT",
 	"prettier": "@companion-module/tools/.prettierrc.json",

--- a/src/enums.ts
+++ b/src/enums.ts
@@ -95,6 +95,11 @@ export enum variableId {
 	TimeS = 'time_s',
 	TimeN = 'time_sign',
 
+	IdPrevious = 'idPrevious',
+	TitlePrevious = 'titlePrevious',
+	NotePrevious = 'notePrevious',
+	CuePrevious = 'cuePrevious',
+
 	IdNow = 'idNow',
 	TitleNow = 'titleNow',
 	NoteNow = 'noteNow',

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -73,3 +73,24 @@ export function eventsToChoices(events: OntimeEvent[]): DropdownChoice[] {
 export function getAuxTimerState(ontime: OntimeV3, index = 'auxtimer1') {
 	return ontime.state[index as keyof RuntimeStore] as unknown as SimpleTimerState
 }
+
+export function findPreviousPlayableEvent(ontime: OntimeV3): OntimeEvent | null {
+	if (ontime.state.eventNow === null) {
+		return null
+	}
+
+	const nowId = ontime.state.eventNow.id
+	let now = false
+
+	for (let i = ontime.events.length - 1; i >= 0; i--) {
+		if (!now && ontime.events[i].id === nowId) {
+			now = true
+			continue
+		}
+		if (now && !ontime.events[i].skip ) { 
+			return ontime.events[i]
+		}
+	}
+
+	return null
+}

--- a/src/v3/connection.ts
+++ b/src/v3/connection.ts
@@ -288,11 +288,9 @@ export async function fetchAllEvents(self: OnTimeInstance, ontime: OntimeV3): Pr
 			return
 		}
 		rundownEtag = response.headers.get('Etag') ?? ''
-		const data = (await response.json()) as OntimeEvent[]
-		self.log('debug', `fetched ${data.length} events`)
-		ontime.events = data
-
-		self.init_actions()
+		const data = (await response.json()) as OntimeBaseEvent[]
+		ontime.events = data.filter((entry) => entry.type === SupportedEvent.Event) as OntimeEvent[]
+		self.log('debug', `fetched ${ontime.events.length} events`)
 	} catch (e: any) {
 		ontime.events = []
 		self.log('error', 'failed to fetch events from ontime')

--- a/src/v3/connection.ts
+++ b/src/v3/connection.ts
@@ -222,6 +222,9 @@ export function connect(self: OnTimeInstance, ontime: OntimeV3): void {
 					const majorVersion = payload.split('.').at(0)
 					if (majorVersion === '3') {
 						self.updateStatus(InstanceStatus.Ok, payload)
+						self.log('debug', 'refetching events')
+						fetchAllEvents(self, ontime)
+						self.init_actions()
 					} else {
 						self.updateStatus(InstanceStatus.ConnectionFailure, 'Unsupported version: see log')
 						self.log(
@@ -237,14 +240,9 @@ export function connect(self: OnTimeInstance, ontime: OntimeV3): void {
 						break
 					}
 					self.log('debug', 'refetching events')
-					void fetchAllEvents(self, ontime).then(
-						() => {
-							self.init_actions()
-						},
-						(e: any) => {
-							self.log('debug', e)
-						}
-					)
+					fetchAllEvents(self, ontime)
+					self.init_actions()
+
 					break
 				}
 			}

--- a/src/v3/connection.ts
+++ b/src/v3/connection.ts
@@ -242,7 +242,11 @@ export function connect(self: OnTimeInstance, ontime: OntimeV3): void {
 					if (majorVersion === '3') {
 						self.updateStatus(InstanceStatus.Ok, payload)
 						self.log('debug', 'refetching events')
-						fetchAllEvents(self, ontime).then(() => self.init_actions())
+						fetchAllEvents(self, ontime).then(() => {
+							self.init_actions()
+							const prev = findPreviousPlayableEvent(ontime)
+							updateEventPrevious(prev)
+						})
 					} else {
 						self.updateStatus(InstanceStatus.ConnectionFailure, 'Unsupported version: see log')
 						self.log(

--- a/src/v3/variables.ts
+++ b/src/v3/variables.ts
@@ -117,7 +117,22 @@ export function variables(): CompanionVariableDefinition[] {
 			name: 'Rundown expected end (hh:mm:ss)',
 			variableId: variableId.ExpectedEnd,
 		},
-		//eventNow.id
+		{
+			name: 'ID of previous event',
+			variableId: variableId.IdPrevious,
+		},
+		{
+			name: 'Title of previous event',
+			variableId: variableId.TitlePrevious,
+		},
+		{
+			name: 'Note of previous event',
+			variableId: variableId.NotePrevious,
+		},
+		{
+			name: 'Cue of previous event',
+			variableId: variableId.CuePrevious,
+		},
 		{
 			name: 'ID of current event',
 			variableId: variableId.IdNow,


### PR DESCRIPTION
#71 
This improves on the event fetching by filtering for the event type so bloks and delayed don't show up in the drop-down menus

There is also added a fetch events call on connection so the list is available as soon as possible 

And the previous event that is not skipped is added as a variable 