### PR TITLE
New offset preset

### DIFF
--- a/src/enums.ts
+++ b/src/enums.ts
@@ -147,6 +147,13 @@ export enum variableId {
 	ExpectedEnd = 'expectedEnd_hms',
 }
 
+export enum OffsetState {
+	On = 'on',
+	Behind = 'behind',
+	Ahead = 'ahead',
+	Both = 'both',
+}
+
 export enum deprecatedVariableId {
 	SubtitleNow = 'subtitleNow',
 	SpeakerNow = 'speakerNow',

--- a/src/v3/feedbacks/offset.ts
+++ b/src/v3/feedbacks/offset.ts
@@ -1,14 +1,7 @@
 import { CompanionFeedbackBooleanEvent, CompanionFeedbackDefinition } from '@companion-module/base'
 import { OntimeV3 } from '../ontimev3'
-import { feedbackId } from '../../enums'
+import {feedbackId, OffsetState} from '../../enums'
 import { DangerRed, White } from '../../assets/colours'
-
-enum OffsetState {
-	On = 'on',
-	Behind = 'behind',
-	Ahead = 'ahead',
-	Both = 'both',
-}
 
 export function createOffsetFeedbacks(ontime: OntimeV3): { [id: string]: CompanionFeedbackDefinition } {
 	function offset(feedback: CompanionFeedbackBooleanEvent): boolean {

--- a/src/v3/presets.ts
+++ b/src/v3/presets.ts
@@ -4,7 +4,7 @@ import {
 	CompanionPresetDefinitions,
 } from '@companion-module/base'
 import * as icons from '../assets/icons'
-import { ActionId, feedbackId } from '../enums'
+import {ActionId, feedbackId, OffsetState} from '../enums'
 import { TimerPhase } from './ontime-types'
 import { graphics } from 'companion-module-utils'
 import {
@@ -408,6 +408,44 @@ const rundownPresets: { [id: string]: CompanionButtonPresetDefinition } = {
 		],
 		feedbacks: [],
 	},
+	offset: {
+		type: 'button',
+		category: 'rundown',
+		name: 'Current offset',
+		style: {
+			...defaultStyle,
+			size: '14',
+			text: '$(ontime:rundown_offset_hms)',
+		},
+		previewStyle: {
+			...defaultStyle,
+			size: '14',
+			text: '00:05:00',
+		},
+		feedbacks: [
+			{
+				feedbackId: feedbackId.RundownOffset,
+				options: {
+					state: OffsetState.Ahead,
+					margin: 10
+				},
+				style: {
+					bgcolor: PlaybackGreen,
+				},
+			},
+			{
+				feedbackId: feedbackId.RundownOffset,
+				options: {
+					state: OffsetState.Behind,
+					margin: 10
+				},
+				style: {
+					bgcolor: PlaybackRed,
+				},
+			},
+		],
+		steps: []
+	}
 }
 
 const messagePresets: { [id: string]: CompanionButtonPresetDefinition } = {

--- a/src/v3/presets.ts
+++ b/src/v3/presets.ts
@@ -410,7 +410,7 @@ const rundownPresets: { [id: string]: CompanionButtonPresetDefinition } = {
 	},
 	offset: {
 		type: 'button',
-		category: 'rundown',
+		category: 'Rundown',
 		name: 'Current offset',
 		style: {
 			...defaultStyle,
@@ -420,7 +420,7 @@ const rundownPresets: { [id: string]: CompanionButtonPresetDefinition } = {
 		previewStyle: {
 			...defaultStyle,
 			size: '14',
-			text: '00:05:00',
+			text: '00:00:05',
 		},
 		feedbacks: [
 			{


### PR DESCRIPTION
Adds a preset where the user can see the current offset is displayed and the background is changed based on whether everything is behind or ahead.

| State   | Preview                                                                                             |
|---------|-----------------------------------------------------------------------------------------------------|
| behind   | ![](https://github.com/user-attachments/assets/532b2092-1d76-469e-b8af-a35f6c203463)               |
| ahead  | ![](https://github.com/user-attachments/assets/23b6814e-f4b1-4af9-90f8-1d7bc6f198a4)               |
| preview or on time | ![](https://github.com/user-attachments/assets/1ccb73ec-4cf9-411e-8d94-86a44e2e18bf)               |
