### PR TITLE
FIX: Rundown Offset Feeddback

### DIFF
--- a/src/v3/feedbacks/offset.ts
+++ b/src/v3/feedbacks/offset.ts
@@ -7,7 +7,7 @@ export function createOffsetFeedbacks(ontime: OntimeV3): { [id: string]: Compani
 	function offset(feedback: CompanionFeedbackBooleanEvent): boolean {
 		const state = feedback.options.state as OffsetState | undefined
 		if (!state) return false
-		if (ontime.state.runtime.offset === null) return false
+		if (ontime.state.runtime.offset === null || ontime.state.runtime.offset === undefined) return false
 		const margin = Number(feedback.options.margin)
 		const offset = ontime.state.runtime.offset / 1000
 		switch (state) {

--- a/src/v3/feedbacks/offset.ts
+++ b/src/v3/feedbacks/offset.ts
@@ -1,14 +1,15 @@
 import { CompanionFeedbackBooleanEvent, CompanionFeedbackDefinition } from '@companion-module/base'
 import { OntimeV3 } from '../ontimev3'
-import {feedbackId, OffsetState} from '../../enums'
+import { feedbackId, OffsetState } from '../../enums'
 import { DangerRed, White } from '../../assets/colours'
 
 export function createOffsetFeedbacks(ontime: OntimeV3): { [id: string]: CompanionFeedbackDefinition } {
 	function offset(feedback: CompanionFeedbackBooleanEvent): boolean {
 		const state = feedback.options.state as OffsetState | undefined
 		if (!state) return false
+		if (ontime.state.runtime.offset === null) return false
 		const margin = Number(feedback.options.margin)
-		const offset = (ontime.state.runtime.offset ?? 0) / 1000
+		const offset = ontime.state.runtime.offset / 1000
 		switch (state) {
 			case OffsetState.On:
 				return offset > -margin && offset < margin

--- a/src/v3/variables.ts
+++ b/src/v3/variables.ts
@@ -202,10 +202,6 @@ export function variables(): CompanionVariableDefinition[] {
 			variableId: variableId.AuxTimerDurationMs + '-1',
 		},
 		{
-			name: 'Aux timer 1 duration (hh:mm:ss)',
-			variableId: variableId.AuxTimerDurationMs + '-1',
-		},
-		{
 			name: 'Aux timer 1 current (hh:mm:ss)',
 			variableId: variableId.AuxTimerCurrent + '-1',
 		},


### PR DESCRIPTION
If there is no offset
then none of the options should trigger
closes #97 and #89
